### PR TITLE
テストとCI設定を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'yarn'
+      - run: yarn install --frozen-lockfile
+      - run: yarn test

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ yarn preview
 - `src/App.jsx`: アプリ全体のレイアウト
 - `src/Timer.jsx`: 日時表示コンポーネント
 - `src/index.jsx`: エントリポイント
+- `src/App.test.jsx`: App コンポーネントのテスト
+- `src/Timer.test.jsx`: Timer コンポーネントのテスト（レンダリング・表示・時刻更新）
 - `public/`: favicon や manifest などの静的ファイル
 
 ## 補足

--- a/src/Timer.test.jsx
+++ b/src/Timer.test.jsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { act } from 'react-dom/test-utils';
+import { afterEach, vi } from 'vitest';
+import Timer from './Timer.jsx';
+
+let container = null;
+
+/**
+ * Timer コンポーネントを DOM にレンダリングし、コンテナ要素を返す
+ * @returns {HTMLElement} Timer をレンダリングしたコンテナ要素
+ */
+function renderTimer() {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+
+  act(() => {
+    ReactDOM.render(<Timer />, container);
+  });
+
+  return container;
+}
+
+afterEach(() => {
+  if (container) {
+    act(() => {
+      ReactDOM.unmountComponentAtNode(container);
+    });
+    container.remove();
+    container = null;
+  }
+
+  document.body.innerHTML = '';
+  vi.useRealTimers();
+});
+
+it('クラッシュせずにレンダリングできる', () => {
+  vi.useFakeTimers();
+
+  renderTimer();
+});
+
+it('.timer div に時刻が表示される', () => {
+  vi.useFakeTimers();
+
+  renderTimer();
+
+  const timer = document.querySelector('.timer');
+
+  expect(timer).not.toBeNull();
+  expect(timer.textContent.trim()).not.toBe('');
+});
+
+it('1秒後に時刻が更新される', () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2020-01-01T00:00:00.000Z'));
+
+  renderTimer();
+
+  const timer = document.querySelector('.timer');
+  const initialText = timer.textContent;
+
+  act(() => {
+    vi.advanceTimersByTime(1000);
+  });
+
+  expect(timer.textContent).not.toBe(initialText);
+});


### PR DESCRIPTION
## Summary
- `src/Timer.test.jsx` を新規追加（レンダリング・表示・時刻更新の3テスト）
- README にテストファイルの説明を追記
- GitHub Actions CI ワークフロー (`.github/workflows/ci.yml`) を追加（push/PR時に `yarn test` を自動実行）

## Test plan
- [x] CI が通ることを確認
- [x] `yarn test` がローカルで全テストパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)