### PR TITLE
undici を 7.29.0 に固定（Dependabot alert #225 の脆弱性対応）

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
     "jsdom": "^29.0.1",
     "vite": "^8.0.16",
     "vitest": "^4.1.2"
+  },
+  "resolutions": {
+    "undici": "7.29.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -728,10 +728,10 @@ tslib@^2.4.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
-undici@^7.24.5:
-  version "7.28.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-7.28.0.tgz#97d64564198b285bc281f0e8e29597e3d11fe7ec"
-  integrity sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==
+undici@7.29.0, undici@^7.24.5:
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-7.29.0.tgz#ae0f6f62e06e057a9cbb7b2b5fde2bb74f791b8f"
+  integrity sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==
 
 "vite@^6.0.0 || ^7.0.0 || ^8.0.0", vite@^8.0.16:
   version "8.0.16"


### PR DESCRIPTION
## 概要
- jsdom の推移的依存である `undici` に高深刻度の脆弱性（[GHSA-4cwx-7wf7-3272](https://github.com/advisories/GHSA-4cwx-7wf7-3272) / CVE-2026-13697）があったため、`resolutions` で `7.29.0` に固定しました
- 対象: [Dependabot alert #225](https://github.com/maangie/react_watch/security/dependabot/225)

## 脆弱性の内容
undici のキャッシュインターセプター（`interceptors.cache()`）が、不正な形式の `Cache-Control: private` ディレクティブを誤ってパースし、共有キャッシュモード使用時に他ユーザー向けのレスポンス（Set-Cookie 等を含む）が別ユーザーに漏洩し得る問題（CVSS 7.4 / High）。

- 影響バージョン: `>= 7.0.0, < 7.29.0`
- 修正バージョン: `7.29.0`（本PRで適用）／8系では `8.9.0`

## 変更内容
- `package.json` に `resolutions.undici: "7.29.0"` を追加
- `yarn.lock` を更新して `undici` の解決バージョンを `7.29.0` に固定

## テスト
- [x] `yarn test` 全4件パス

## 備考
undici の最新版は `8.10.0` ですが、メジャーバージョンアップとなるため破壊的変更の確認が必要と判断し、今回は脆弱性修正の最小バージョンである `7.29.0` のみ対応しました。`8.10.0` への追随は別途対応予定です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)