### PR TITLE
package.json に type: module を追加して Vite の非推奨警告を解消

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "quick_react",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "dependencies": {
     "react": "^16.11.0",
     "react-dom": "^16.11.0"


### PR DESCRIPTION
## 概要
PR #41 のマージ後に追加した「`type: module` 修正コミット」が、マージのタイミングの都合で master に取り込まれていなかったため、改めて別PRとして反映します。

## 背景
`vite.config.js` は ESM構文で書かれているが、`package.json` に `"type": "module"` が無く CommonJS として読み込まれていたため、Vite 8.2.2 から `configLoader: 'native'` に関する将来の非推奨警告が出るようになっていた。プロジェクト内に `require`/`module.exports` の使用が無いことを確認した上で `"type": "module"` を追加し、警告を解消した。

## テスト
- [x] `yarn test`（4件パス）
- [x] `yarn build`（成功、警告なし）
- [x] `yarn preview`（HTTP 200 で起動確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)